### PR TITLE
Remove curly brackets from AssemblyTitle.

### DIFF
--- a/root/name/Properties/AssemblyInfo.cs
+++ b/root/name/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle({"test"})]
+[assembly: AssemblyTitle("test")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]


### PR DESCRIPTION
I get the following error when running Make on a clean install:

    make: build debug -quiet
    make: run debug
    Properties/AssemblyInfo.cs(8,25): error CS1525: Unexpected symbol `{'
    make: *** [build.debug-quiet] Error 1

Removing the curly brackets resolves the issue.